### PR TITLE
fix half ratings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,73 +1,74 @@
-/** @jsx React.DOM */
+'use strict';
+
 var React = require('react');
 
-var Icon = React.createClass({displayName: "Icon",
-  render : function(){
+var Icon = React.createClass({
+  displayName: 'Icon',
+
+  render: function render() {
     var iStyle = {
-      cursor : 'pointer'
+      cursor: 'pointer'
     };
     var className = this.props.toggled ? this.props.toggledClassName : this.props.untoggledClassName;
-    return (
-      React.createElement("i", {className: className, onMouseMove: this.props.onMouseEnter, style: iStyle, onClick: this.props.onClickRating})
-    );
+    return React.createElement('i', { className: className, onMouseMove: this.props.onMouseEnter, style: iStyle, onClick: this.props.onClickRating });
   }
 });
 
-var IconRating = React.createClass({displayName: "IconRating",
-  getInitialState : function(){
+var IconRating = React.createClass({
+  displayName: 'IconRating',
+
+  getInitialState: function getInitialState() {
     return {
-      currentRating : this.props.currentRating || 0,
-      max : this.props.max || 5,
-      currentRating_hover : 0,
-      hovering : false
+      currentRating: this.props.currentRating || 0,
+      max: this.props.max || 5,
+      currentRating_hover: 0,
+      hovering: false
     };
   },
-  onMouseEnter : function(currentRating, e, id){
+  onMouseEnter: function onMouseEnter(currentRating, e, id) {
     var rating = currentRating;
-    if((e.nativeEvent.clientX) < (e.target.offsetLeft + (e.target.offsetWidth / 2))){
+    if (e.nativeEvent.clientX < e.target.offsetLeft + e.target.offsetWidth / 2) {
       rating -= .5;
     }
     this.setState({
-      currentRating_hover : rating,
-      hovering : true
+      currentRating_hover: rating,
+      hovering: true
     });
   },
-  onMouseLeave : function(currentRating, e, id){
+  onMouseLeave: function onMouseLeave(currentRating, e, id) {
     this.setState({
-      hovering : false
+      hovering: false
     });
   },
-  onClickRating : function(currentRating, e, id){
+  onClickRating: function onClickRating(currentRating, e, id) {
     this.setState({
-      currentRating : this.state.currentRating_hover
+      currentRating: this.state.currentRating_hover
     });
-    if(this.props.onChange){
+    if (this.props.onChange) {
       this.props.onChange(currentRating);
     }
   },
-  render: function() {
+  render: function render() {
     var ratings = [];
-    var toggled = false, rating, halfClassName,
-        f = function() {},
+    var toggled = false,
+        rating,
+        halfClassName,
+        f = function f() {},
         onMouseEnter = this.props.viewOnly ? f : this.onMouseEnter,
         onClickRating = this.props.viewOnly ? f : this.onClickRating;
-    for(var i=1;i<=this.state.max;++i){
-      rating = this.state['currentRating' + (this.state.hovering ? '_hover':'')];
-      toggled = i <= Math.round(rating) ? true : false;
+    for (var i = 1; i <= this.state.max; ++i) {
+      rating = this.state['currentRating' + (this.state.hovering ? '_hover' : '')];
+      toggled = i <= Math.round(this.props.halfClassName ? rating + 0.25 : rating);
       halfClassName = null;
-      if(this.props.halfClassName &&
-         Math.round(rating) == i &&
-         Math.floor(rating) != rating){
-          halfClassName = this.props.halfClassName;
+      if (this.props.halfClassName && (rating >= i - 0.75 && rating < i - 0.25)) {
+        halfClassName = this.props.halfClassName;
       }
-      ratings.push(
-          React.createElement(Icon, {key: i, toggledClassName: halfClassName || this.props.toggledClassName, untoggledClassName: this.props.untoggledClassName, onMouseEnter: onMouseEnter.bind(this,i), onClickRating: onClickRating.bind(this,i), toggled: toggled})
-      );
+      ratings.push(React.createElement(Icon, { key: i, toggledClassName: halfClassName || this.props.toggledClassName, untoggledClassName: this.props.untoggledClassName, onMouseEnter: onMouseEnter.bind(this, i), onClickRating: onClickRating.bind(this, i), toggled: toggled }));
     }
-    return (
-      React.createElement("div", {className: this.props.className, onMouseLeave: this.onMouseLeave}, 
-        ratings
-      )
+    return React.createElement(
+      'div',
+      { className: this.props.className, onMouseLeave: this.onMouseLeave },
+      ratings
     );
   }
 });

--- a/index.jsx
+++ b/index.jsx
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 var React = require('react');
 
 var Icon = React.createClass({
@@ -53,11 +52,10 @@ var IconRating = React.createClass({
         onClickRating = this.props.viewOnly ? f : this.onClickRating;
     for(var i=1;i<=this.state.max;++i){
       rating = this.state['currentRating' + (this.state.hovering ? '_hover':'')];
-      toggled = i <= Math.round(rating) ? true : false;
+      toggled = i <= Math.round(this.props.halfClassName ? rating + 0.25 : rating);
       halfClassName = null;
       if(this.props.halfClassName &&
-         Math.round(rating) == i &&
-         Math.floor(rating) != rating){
+         ((rating >= i - 0.75) && (rating < i - 0.25))) {
           halfClassName = this.props.halfClassName;
       }
       ratings.push(

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "react component for simple web font backed ratings",
   "main": "index.js",
   "scripts": {
+    "build": "babel index.jsx -o index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [


### PR DESCRIPTION
Currently half ratings are shown incorrectly for some `currentRating` values (e.g. `4.2` shows as 3 and a half stars). This fix implements this logic:

`currentRating < 0.25` - shows empty star,
`0.25 <= currentRating < 0.75` - shows half star,
`0.75 <= currentRating` - shows full star.